### PR TITLE
Bump up f8a-pypi-insights for production from 2020-10-30 to 2021-01-06

### DIFF
--- a/f8a-pypi-insights.yaml
+++ b/f8a-pypi-insights.yaml
@@ -15,6 +15,23 @@ services:
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-pypi-insights
       MODEL_VERSION: "2020-10-03"
   - name: production
+# ** THIS COMMENT BLOCK IS GENERATED AND REPLACED BY AN AUTOMATED SCRIPT; DO NOT UPDATE IT MANUALLY **
+# 
+# - Hyper parameters :: 
+#     deployment: staging
+#     f1_score_at_30: 3.6222653164811096e-05
+#     f1_score_at_50: 2.4148702166775773e-05
+#     latent_factor: 40
+#     maximum_length_of_manifest: 100
+#     minimum_length_of_manifest: 2
+#     model_version: 2021-01-06
+#     precision_at_30: 1.811184061580258e-05
+#     precision_at_50: 1.2074560410535055e-05
+#     recall_at_30: 0.638148148148148
+#     recall_at_50: 0.6964814814814815
+# 
+# Criteria for promotion is `current_recall_at_30 >= prev_recall_at_30`
+# 
     parameters:
       CPU_REQUEST: 300m
       CPU_LIMIT: 1000m
@@ -23,6 +40,6 @@ services:
       REPLICAS: 1
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-pypi-insights
-      MODEL_VERSION: "2020-10-30"
+      MODEL_VERSION: "2021-01-06"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/f8a-pypi-insights/


### PR DESCRIPTION
Current deployed model details:
- Model version :: `2020-10-30`
- Hyper parameters :: 
    deployment: staging
    f1_score_at_30: 2.6222653164811097e-05
    f1_score_at_50: 1.3148702166775773e-05
    latent_factor: 40
    maximum_length_of_manifest: 100
    minimum_length_of_manifest: 2
    model_version: 2020-10-30
    precision_at_30: 1.559324762077222e-05
    precision_at_50: 1.1468582121084083e-05
    recall_at_30: 0.4735294117647059
    recall_at_50: 0.5300653594771242

New model details:
- Model version :: `2021-01-06`
- Hyper parameters :: 
    deployment: staging
    f1_score_at_30: 3.6222653164811096e-05
    f1_score_at_50: 2.4148702166775773e-05
    latent_factor: 40
    maximum_length_of_manifest: 100
    minimum_length_of_manifest: 2
    model_version: 2021-01-06
    precision_at_30: 1.811184061580258e-05
    precision_at_50: 1.2074560410535055e-05
    recall_at_30: 0.638148148148148
    recall_at_50: 0.6964814814814815

Criteria for promotion is `current_recall_at_30 >= prev_recall_at_30`
