### PR TITLE
Bump up f8a-pypi-insights for production from 2021-03-01 to 2021-03-02

### DIFF
--- a/f8a-pypi-insights.yaml
+++ b/f8a-pypi-insights.yaml
@@ -35,10 +35,10 @@ services:
       REPLICAS: 1
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-pypi-insights
-      MODEL_VERSION: '2021-03-01'
+      MODEL_VERSION: '2021-03-02'
     comments:
       deployment: production
-      model_version: '2021-03-01'
+      model_version: '2021-03-02'
       minimum_length_of_manifest: 50
       maximum_length_of_manifest: 200
       latent_factor: 180


### PR DESCRIPTION
Current deployed model details:
- Model version :: `2021-03-01`
- Hyper parameters :: 
    deployment: production
    f1_score_at_30: 2.6222653164811097e-05
    f1_score_at_50: 1.3148702166775773e-05
    latent_factor: 40
    maximum_length_of_manifest: 100
    minimum_length_of_manifest: 2
    model_version: 2021-03-01
    precision_at_30: 1.559324762077222e-05
    precision_at_50: 1.1468582121084083e-05
    recall_at_30: 0.4735294117647059
    recall_at_50: 0.5300653594771242


New model details:
- Model version :: `2021-03-02`
- Hyper parameters :: 
    deployment: production
    f1_score_at_30: 0.5827453847959759
    f1_score_at_50: 0.7535568193794179
    latent_factor: 180
    maximum_length_of_manifest: 200
    minimum_length_of_manifest: 50
    model_version: 2021-03-02
    precision_at_30: 0.53654321
    precision_at_50: 0.71123456
    recall_at_30: 0.63765432
    recall_at_50: 0.80123456


Criteria for promotion is `current_recall_at_30 >= deployed_recall_at_30`
