### PR TITLE
Bump up f8a-pypi-insights for staging from 2021-02-22 to 2020-07-14

### DIFF
--- a/f8a-pypi-insights.yaml
+++ b/f8a-pypi-insights.yaml
@@ -12,20 +12,9 @@ services:
       REPLICAS: 1
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-pypi-insights
-      MODEL_VERSION: '2021-02-22'
+      MODEL_VERSION: '2020-07-14'
     comments:
-      deployment: staging
-      model_version: '2021-02-22'
-      minimum_length_of_manifest: 50
-      maximum_length_of_manifest: 200
-      latent_factor: 180
-      precision_at_30: 0.53123456
-      recall_at_30: 0.63234567
-      f1_score_at_30: 0.5773970115844186
-      precision_at_50: 0.70123456
-      recall_at_50: 0.80123456
-      f1_score_at_50: 0.7479067045829116
-      promotion_criteria: current_recall_at_30 >= deployed_recall_at_30
+      promotion_criteria: Always move to latest model
   - name: production
     parameters:
       CPU_REQUEST: 300m


### PR DESCRIPTION
Current deployed model details:
- Model version :: `2021-02-22`
- Hyper parameters :: 
    version: 2019-01-03


New model details:
- Model version :: `2020-07-14`
- Hyper parameters :: 

Criteria for promotion is `Always move to latest model`
